### PR TITLE
Add header links and simple login

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,13 +12,17 @@
       <div class="site-logo">
         <img src="assets/logo.png" alt="BrickHolder" />
       </div>
+      <nav class="header-links" id="extra-links">
+        <a href="collection.html">Моя коллекция</a>
+        <a href="#">Наборы</a>
+        <a href="#">Минифигурки</a>
+      </nav>
       <div class="header-search">
         <label for="search-input">Поиск:</label>
         <input type="text" id="search-input" placeholder="...">
       </div>
       <nav class="nav-login">
-        <a href="login.html">Вход</a>
-        <a href="collection.html">Моя коллекция</a>
+        <a id="login-link" href="login.html">Вход</a>
       </nav>
     </div>
   </header>
@@ -60,5 +64,21 @@
   <footer class="site-footer">
     <p>BrickHolder 2025</p>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const links = document.getElementById('extra-links');
+      const loginLink = document.getElementById('login-link');
+      const username = localStorage.getItem('username');
+      if (username) {
+        links.style.display = 'flex';
+        loginLink.textContent = username;
+        loginLink.removeAttribute('href');
+      } else {
+        links.style.display = 'none';
+        loginLink.textContent = 'Войти';
+        loginLink.setAttribute('href', 'login.html');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -24,22 +24,20 @@
 
   <main class="container form-container">
     <h1 class="form-title">Регистрация</h1>
-    <form action="#" method="post" class="auth-form">
+    <form class="auth-form" id="auth-form">
       <label>
-        <span class="sr-only">Логин*</span>
-        <input type="text" name="username" placeholder="Логин*" required>
+        <input id="login-input" type="text" placeholder="Логин *" required>
+      </label>
+      <div class="form-hint">* Придумайте уникальное имя</div>
+      <label>
+        <input type="email" placeholder="E-mail">
       </label>
       <label>
-        <span class="sr-only">E-mail</span>
-        <input type="email" name="email" placeholder="E-mail">
-      </label>
-      <label>
-        <span class="sr-only">Пароль</span>
-        <input type="password" name="password" placeholder="Пароль">
+        <input type="password" placeholder="Пароль">
       </label>
       <div class="form-actions">
-        <button type="submit" class="btn-primary">Зарегистрироваться</button>
-        <a href="login.html" class="btn-secondary">Войти</a>
+        <button id="register-btn" type="button" class="btn-primary">Зарегистрироваться</button>
+        <button id="login-btn" type="button" class="btn-secondary">Войти</button>
       </div>
     </form>
   </main>
@@ -47,7 +45,18 @@
   <footer class="site-footer">
     <p>BrickHolder 2025</p>
   </footer>
-</body>
-</html>
+  <script>
+    function processAuth() {
+      const login = document.getElementById('login-input').value.trim();
+      if (!login) {
+        alert('Введите логин');
+        return;
+      }
+      localStorage.setItem('username', login);
+      window.location.href = 'index.html';
+    }
+    document.getElementById('register-btn').addEventListener('click', processAuth);
+    document.getElementById('login-btn').addEventListener('click', processAuth);
+  </script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5,6 +5,16 @@
   font-family: Arial, sans-serif;
 }
 
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .container {
   width: 90%;
   max-width: 1200px;
@@ -35,6 +45,18 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 4px 8px;
+}
+
+.header-links {
+  display: flex;
+  gap: 15px;
+  margin-left: 20px;
+}
+
+.header-links a {
+  text-decoration: none;
+  color: #333;
+  font-weight: bold;
 }
 
 .header-search label {
@@ -142,7 +164,8 @@
   color: #fff;
   text-align: center;
   padding: 15px 0;
-  margin-top: 40px;
+  margin-top: auto;
+  width: 100%;
 }
 
 /* Responsive */
@@ -224,4 +247,46 @@
   max-width: 400px;
   display: block;
   margin: 20px 0;
+}
+
+.form-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.auth-form input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.form-hint {
+  font-size: 12px;
+  color: #666;
+  margin-bottom: 10px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.btn-secondary {
+  display: inline-block;
+  padding: 6px 12px;
+  background: #ddd;
+  color: #333;
+  text-decoration: none;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- add user navigation items and hide until login
- simplify login page layout
- implement toy login using localStorage
- keep footer at bottom via flex layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aad23fe00832e80d0a1d204ffb456