### PR TITLE
Implement interactive collection page

### DIFF
--- a/backend/data-service/handlers/set.go
+++ b/backend/data-service/handlers/set.go
@@ -45,7 +45,14 @@ func CreateSetHandler(c *gin.Context) {
 // @Tags lego
 func GetAllSetHandler(c *gin.Context) {
 	var products []models.Set
-	db.DB.Find(&products)
+	query := c.Query("q")
+	if query != "" {
+		pattern := "%" + query + "%"
+		db.DB.Where("set_num ILIKE ? OR name ILIKE ?", pattern, pattern).Find(&products)
+	} else {
+		db.DB.Find(&products)
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"data": products,
 	})

--- a/frontend/css/collection.css
+++ b/frontend/css/collection.css
@@ -13,13 +13,34 @@
 
 .collection-container h2 { font-size:20px; margin-bottom:15px; }
 .collections-wrapper { display:flex; gap:20px; flex-wrap:wrap; }
-.lists-panel { background:#f9f9f9; border-radius:8px; width:200px; padding:15px; }
+.lists-panel { background:#f9f9f9; border-radius:8px; width:200px; padding:15px; display:flex; flex-direction:column; gap:10px; }
 .lists-panel h3 { font-size:16px; margin-bottom:10px; }
 
 .empty-state { background:#f9f9f9; border-radius:8px; flex:1; padding:30px; text-align:center; }
 .empty-state p { font-size:14px; color:#333; margin-bottom:20px; line-height:1.5; }
 .empty-state img { width:160px; height:auto; margin-bottom:20px; }
 .btn-primary { background:#a4eb34; border:none; border-radius:20px; padding:8px 20px; font-size:14px; color:#fff; cursor:pointer; }
+
+.list-section { background:#f9f9f9; border-radius:8px; flex:1; padding:20px; }
+.list-form .form-group { margin-bottom:15px; }
+.list-form input, .list-form textarea { width:100%; padding:8px; border:1px solid #ccc; border-radius:20px; font-size:14px; }
+.form-buttons { display:flex; justify-content:space-between; margin-bottom:15px; }
+.btn-delete { background:#e57373; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
+.btn-save { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
+.search-add { display:flex; gap:10px; align-items:center; margin-bottom:10px; }
+.search-input { flex:1; padding:8px; border:1px solid #ccc; border-radius:20px; font-size:14px; }
+.btn-add-set { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
+.search-results { max-height:150px; overflow-y:auto; margin-bottom:10px; background:#fff; border:1px solid #ccc; border-radius:8px; }
+.search-item { padding:4px 8px; cursor:pointer; }
+.search-item:hover { background:#eee; }
+.sets-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:20px; }
+.set-card { background:#fff; border:1px solid #ddd; border-radius:8px; overflow:hidden; }
+.set-card img { width:100%; height:135px; object-fit:cover; }
+.set-info { padding:8px; font-size:14px; display:flex; flex-wrap:wrap; }
+.set-code { font-weight:bold; width:100%; }
+.set-name { flex:1; }
+.set-parts { margin-left:auto; font-size:12px; }
+.set-year { width:100%; font-size:12px; color:#777; }
 
 .site-footer {
   background: #333;
@@ -35,5 +56,5 @@
   .header-container{ flex-wrap:wrap; justify-content:center; }
   .primary-nav, .header-search, .nav-login{ margin:10px 5px; }
   .collections-wrapper{ flex-direction:column; align-items:center; }
-  .lists-panel, .empty-state{ width:100%; max-width:320px; }
+  .lists-panel, .empty-state, .list-section{ width:100%; max-width:320px; }
 }

--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -1,0 +1,151 @@
+// Collection page interactivity
+
+const listsKey = 'brickholder_lists';
+let lists = JSON.parse(localStorage.getItem(listsKey) || '[]');
+let currentListId = null;
+
+function saveLists() {
+  localStorage.setItem(listsKey, JSON.stringify(lists));
+}
+
+function renderLists() {
+  const panel = document.querySelector('.lists-panel');
+  const listContainer = panel.querySelector('ul') || document.createElement('ul');
+  listContainer.innerHTML = '';
+  listContainer.className = 'list-items';
+  lists.forEach(l => {
+    const li = document.createElement('li');
+    li.textContent = l.name;
+    li.dataset.id = l.id;
+    li.addEventListener('click', () => selectList(l.id));
+    listContainer.appendChild(li);
+  });
+  if (!panel.contains(listContainer)) {
+    panel.appendChild(listContainer);
+  }
+}
+
+function showEmptyState(show) {
+  document.querySelector('.empty-state').style.display = show ? 'block' : 'none';
+  document.querySelector('.list-section').style.display = show ? 'none' : 'block';
+}
+
+function selectList(id) {
+  currentListId = id;
+  const list = lists.find(l => l.id === id);
+  if (!list) return;
+  document.getElementById('list-title').textContent = list.name;
+  document.getElementById('list-name').value = list.name;
+  document.getElementById('list-desc').value = list.description || '';
+  renderSetCards(list);
+  showEmptyState(false);
+}
+
+function renderSetCards(list) {
+  const grid = document.querySelector('.sets-grid');
+  grid.innerHTML = '';
+  list.sets.forEach(s => {
+    const card = document.createElement('div');
+    card.className = 'set-card';
+    card.innerHTML = `
+      <img src="${s.set_img_url || '../assets/sets.jpg'}" alt="${s.set_num}">
+      <div class="set-info">
+        <div class="set-code">${s.set_num}</div>
+        <div class="set-name">${s.name}</div>
+        <div class="set-parts">(${s.num_parts} деталей)</div>
+        <div class="set-year">${s.year}</div>
+      </div>`;
+    grid.appendChild(card);
+  });
+}
+
+function newList() {
+  const id = 'list-' + Date.now();
+  const list = { id, name: 'Новый список', description: '', sets: [] };
+  lists.push(list);
+  saveLists();
+  renderLists();
+  selectList(id);
+  document.getElementById('list-form').style.display = 'block';
+}
+
+function deleteList() {
+  if (!currentListId) return;
+  lists = lists.filter(l => l.id !== currentListId);
+  saveLists();
+  renderLists();
+  showEmptyState(lists.length === 0);
+}
+
+function saveCurrentList(e) {
+  e.preventDefault();
+  if (!currentListId) return;
+  const list = lists.find(l => l.id === currentListId);
+  list.name = document.getElementById('list-name').value.trim() || 'Без названия';
+  list.description = document.getElementById('list-desc').value.trim();
+  saveLists();
+  renderLists();
+  document.getElementById('list-title').textContent = list.name;
+  document.getElementById('list-form').style.display = 'none';
+}
+
+function editList() {
+  document.getElementById('list-form').style.display = 'block';
+}
+
+async function searchSets() {
+  const query = document.getElementById('search-input-set').value.trim();
+  if (!query) return;
+  const res = await fetch(`/api/lego/sets?q=${encodeURIComponent(query)}`);
+  if (!res.ok) return;
+  const data = await res.json();
+  const results = data.data || [];
+  const container = document.getElementById('search-results');
+  container.innerHTML = '';
+  results.forEach(s => {
+    const div = document.createElement('div');
+    div.className = 'search-item';
+    div.textContent = `${s.set_num} - ${s.name}`;
+    div.addEventListener('click', () => {
+      addSetToCurrent(s);
+      container.innerHTML = '';
+      document.getElementById('search-input-set').value = '';
+    });
+    container.appendChild(div);
+  });
+}
+
+function addSetToCurrent(set) {
+  if (!currentListId) return;
+  const list = lists.find(l => l.id === currentListId);
+  if (list.sets.find(s => s.set_num === set.set_num)) return;
+  list.sets.push(set);
+  saveLists();
+  renderSetCards(list);
+}
+
+// header login display
+function initHeader() {
+  const loginLink = document.getElementById('login-link');
+  const username = localStorage.getItem('username');
+  if (username) {
+    loginLink.textContent = username;
+    loginLink.removeAttribute('href');
+  } else {
+    loginLink.textContent = 'Войти';
+    loginLink.setAttribute('href', 'login.html');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderLists();
+  if (lists.length === 0) {
+    showEmptyState(true);
+  }
+  document.querySelector('.new-list-btn').addEventListener('click', newList);
+  document.getElementById('delete-btn').addEventListener('click', deleteList);
+  document.getElementById('list-form').addEventListener('submit', saveCurrentList);
+  document.getElementById('edit-btn').addEventListener('click', editList);
+  document.getElementById('add-set-btn').addEventListener('click', searchSets);
+  initHeader();
+});

--- a/frontend/pages/collection.html
+++ b/frontend/pages/collection.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BrickHolder</title>
+  <link rel="stylesheet" href="../css/style.css">
   <link rel="stylesheet" href="../css/collection.css">
 </head>
 <body>
@@ -12,7 +13,7 @@
       <div class="site-logo">
         <a href="../pages/index.html"><img src="../assets/logo.png" alt="BrickHolder"></a>
       </div>
-      <nav class="primary-nav">
+      <nav class="header-links" id="extra-links">
         <a href="../pages/collection.html">Моя коллекция</a>
         <a href="../pages/set.html">Наборы</a>
         <a href="../pages/minifigures.html">Минифигурки</a>
@@ -21,7 +22,9 @@
         <label for="search-input">Поиск:</label>
         <input type="text" id="search-input" placeholder="...">
       </div>
-      <nav class="nav-login"><a href="../login.html">Halomeny</a></nav>
+      <nav class="nav-login">
+        <a id="login-link" href="../pages/login.html">Вход</a>
+      </nav>
     </div>
   </header>
 
@@ -30,16 +33,40 @@
     <div class="collections-wrapper">
       <aside class="lists-panel">
         <h3>Списки:</h3>
-        <!-- Сюда будут динамически добавляться списки -->
+        <!-- списки -->
+        <button class="btn-primary new-list-btn">Новый список наборов</button>
       </aside>
       <section class="empty-state">
         <p>Пока не создано ни одного списка.<br>Создайте новый список и добавьте первый набор в коллекцию</p>
         <img src="../assets/empty_coll.png" alt="Пустая коллекция">
-        <a href="../pages/newlist.html"><button class="btn-primary new-list-btn">Новый список наборов</button></a>
+      </section>
+      <section class="list-section" style="display:none">
+        <h3 id="list-title">Новый список <button id="edit-btn" class="edit-icon">✎</button></h3>
+        <form id="list-form" style="display:none" class="list-form">
+          <div class="form-group">
+            <label for="list-name">Название списка</label>
+            <input type="text" id="list-name" required>
+          </div>
+          <div class="form-group">
+            <label for="list-desc">Описание</label>
+            <textarea id="list-desc" rows="3"></textarea>
+          </div>
+          <div class="form-buttons">
+            <button type="button" id="delete-btn" class="btn-delete">Удалить список</button>
+            <button type="submit" class="btn-save">Сохранить</button>
+          </div>
+        </form>
+        <div class="search-add">
+          <input type="text" id="search-input-set" class="search-input" placeholder="Поиск по артикулу/названию">
+          <button type="button" id="add-set-btn" class="btn-add-set">Добавить набор</button>
+        </div>
+        <div id="search-results" class="search-results"></div>
+        <div class="sets-grid"></div>
       </section>
     </div>
   </main>
 
   <footer class="site-footer"><p>BrickHolder 2025</p></footer>
+  <script src="../js/collection.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add query search to data-service handler
- redesign collections page layout with header from index
- style interactive list and set cards
- implement collection interaction script

## Testing
- `go vet ./...` *(fails: directory prefix not module)*
- `cd backend/data-service && go vet ./...`
- `cd backend/set-service && go vet ./...`
- `cd backend/authentication-service && go vet ./...` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ad1aa2b64832eb587139d27fe04aa