### PR TITLE
Add interactive search and import button

### DIFF
--- a/frontend/css/collection.css
+++ b/frontend/css/collection.css
@@ -22,12 +22,13 @@
 .btn-primary { background:#a4eb34; border:none; border-radius:20px; padding:8px 20px; font-size:14px; color:#fff; cursor:pointer; }
 
 .list-section { background:#f9f9f9; border-radius:8px; flex:1; padding:20px; }
+.list-items li { cursor:pointer; }
 .list-form .form-group { margin-bottom:15px; }
 .list-form input, .list-form textarea { width:100%; padding:8px; border:1px solid #ccc; border-radius:20px; font-size:14px; }
 .form-buttons { display:flex; justify-content:space-between; margin-bottom:15px; }
 .btn-delete { background:#e57373; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
 .btn-save { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
-.search-add { display:flex; gap:10px; align-items:center; margin-bottom:10px; }
+.search-add { display:flex; gap:10px; align-items:center; margin:10px 0; }
 .search-input { flex:1; padding:8px; border:1px solid #ccc; border-radius:20px; font-size:14px; }
 .btn-add-set { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
 .search-results { max-height:150px; overflow-y:auto; margin-bottom:10px; background:#fff; border:1px solid #ccc; border-radius:8px; }

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -168,6 +168,11 @@ body {
   width: 100%;
 }
 
+.admin-import {
+  margin: 20px 0;
+  text-align: center;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .header-container {

--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -18,10 +18,15 @@ function renderLists() {
     li.textContent = l.name;
     li.dataset.id = l.id;
     li.addEventListener('click', () => selectList(l.id));
+    li.addEventListener('dblclick', () => {
+      selectList(l.id);
+      document.getElementById('list-form').style.display = 'block';
+    });
     listContainer.appendChild(li);
   });
   if (!panel.contains(listContainer)) {
-    panel.appendChild(listContainer);
+    const btn = panel.querySelector('.new-list-btn');
+    panel.insertBefore(listContainer, btn);
   }
 }
 
@@ -93,14 +98,18 @@ function editList() {
   document.getElementById('list-form').style.display = 'block';
 }
 
-async function searchSets() {
+let searchTimeout;
+async function fetchSearchResults() {
   const query = document.getElementById('search-input-set').value.trim();
-  if (!query) return;
+  const container = document.getElementById('search-results');
+  if (!query) {
+    container.innerHTML = '';
+    return;
+  }
   const res = await fetch(`/api/lego/sets?q=${encodeURIComponent(query)}`);
   if (!res.ok) return;
   const data = await res.json();
   const results = data.data || [];
-  const container = document.getElementById('search-results');
   container.innerHTML = '';
   results.forEach(s => {
     const div = document.createElement('div');
@@ -113,6 +122,11 @@ async function searchSets() {
     });
     container.appendChild(div);
   });
+}
+
+function searchSets() {
+  clearTimeout(searchTimeout);
+  searchTimeout = setTimeout(fetchSearchResults, 300);
 }
 
 function addSetToCurrent(set) {
@@ -131,6 +145,12 @@ function initHeader() {
   if (username) {
     loginLink.textContent = username;
     loginLink.removeAttribute('href');
+    loginLink.style.cursor = 'pointer';
+    loginLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('username');
+      window.location.href = 'index.html';
+    });
   } else {
     loginLink.textContent = 'Войти';
     loginLink.setAttribute('href', 'login.html');
@@ -146,6 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('delete-btn').addEventListener('click', deleteList);
   document.getElementById('list-form').addEventListener('submit', saveCurrentList);
   document.getElementById('edit-btn').addEventListener('click', editList);
-  document.getElementById('add-set-btn').addEventListener('click', searchSets);
+  document.getElementById('add-set-btn').addEventListener('click', fetchSearchResults);
+  document.getElementById('search-input-set').addEventListener('input', searchSets);
   initHeader();
 });

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -59,6 +59,10 @@
         </div>
       </div>
     </section>
+
+    <section class="admin-import">
+      <button id="import-btn" class="btn-primary">Импортировать данные</button>
+    </section>
   </main>
 
   <footer class="site-footer">
@@ -73,10 +77,27 @@
         links.style.display = 'flex';
         loginLink.textContent = username;
         loginLink.removeAttribute('href');
+        loginLink.style.cursor = 'pointer';
+        loginLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          localStorage.removeItem('username');
+          window.location.href = 'index.html';
+        });
       } else {
         links.style.display = 'none';
         loginLink.textContent = 'Войти';
         loginLink.setAttribute('href', 'login.html');
+      }
+
+      const importBtn = document.getElementById('import-btn');
+      if (importBtn) {
+        importBtn.addEventListener('click', async () => {
+          await fetch('/api/import/series', {method: 'POST'});
+          await fetch('/api/import/sets', {method: 'POST'});
+          await fetch('/api/import/minifigs', {method: 'POST'});
+          await fetch('/api/import/details', {method: 'POST'});
+          alert('Импорт завершен');
+        });
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- reorder list rendering so new list button appears below lists
- enable editing list info by double-clicking a list name
- make search interactive and fetch suggestions from the DB
- implement logout on username click
- add admin import button on the main page
- adjust styles for better spacing

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `cd backend/set-service && go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ad5f204c4832e9084a0b2e3032a99