### PR TITLE
Add CORS support for set-service

### DIFF
--- a/backend/set-service/go.mod
+++ b/backend/set-service/go.mod
@@ -12,8 +12,9 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
-	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/gin-gonic/gin v1.10.1 // indirect
+       github.com/gin-contrib/sse v1.1.0 // indirect
+       github.com/gin-contrib/cors v1.7.5
+       github.com/gin-gonic/gin v1.10.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect

--- a/backend/set-service/go.sum
+++ b/backend/set-service/go.sum
@@ -21,6 +21,8 @@ github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBv
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
+github.com/gin-contrib/cors v1.7.5 h1:cXC9SmofOrRg0w9PigwGlHG3ztswH6bqq4vJVXnvYMk=
+github.com/gin-contrib/cors v1.7.5/go.mod h1:4q3yi7xBEDDWKapjT2o1V7mScKDDr8k+jZ0fSquGoy0=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
 github.com/go-openapi/jsonpointer v0.21.1 h1:whnzv/pNXtK2FbX/W9yJfRmE2gsmkfahjMKB0fZvcic=

--- a/backend/set-service/main.go
+++ b/backend/set-service/main.go
@@ -17,6 +17,7 @@ import (
 	"set-service/handlers"
 	"set-service/services"
 
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 
@@ -40,6 +41,7 @@ func main() {
 	setsHandler := handlers.NewSetsHandler(client)
 
 	r := gin.Default()
+	r.Use(cors.Default())
 	api := r.Group("/api")
 	{
 		api.GET("/sets", setsHandler.GetSets)


### PR DESCRIPTION
## Summary
- allow cross-origin requests in set-service with gin-contrib/cors

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ae6613c98832ea83e10832bcfca11