### PR TITLE
Fix search API URL

### DIFF
--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -106,8 +106,11 @@ async function fetchSearchResults() {
     container.innerHTML = '';
     return;
   }
-  const res = await fetch('http://localhost:8080/api/lego/sets?q=' +
-                        encodeURIComponent(query));
+  const baseURL = window.location.protocol === 'file:' ?
+                   'http://localhost:8081' : '';
+  const res = await fetch(
+    `${baseURL}/api/lego/sets?q=${encodeURIComponent(query)}`
+  );
   if (!res.ok) return;
   const data = await res.json();
   const results = data.data || [];


### PR DESCRIPTION
## Summary
- fix `collection.js` to query the data-service on port 8081

## Testing
- `go run main.go` *(fails: exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_684aec125350832ebf4298fe5b559839