### PR TITLE
Fix search API URL

### DIFF
--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -106,8 +106,10 @@ async function fetchSearchResults() {
     container.innerHTML = '';
     return;
   }
-  const res = await fetch('http://localhost:8080/api/lego/sets?q=' +
-                        encodeURIComponent(query));
+  const baseURL = 'http://localhost:8081';
+  const res = await fetch(
+    `${baseURL}/api/lego/sets?q=${encodeURIComponent(query)}`
+  );
   if (!res.ok) return;
   const data = await res.json();
   const results = data.data || [];


### PR DESCRIPTION
## Summary
- fix `collection.js` to always query the data-service on port 8081

## Testing
- `go build ./...` in `backend/data-service`
- `go build ./...` in `backend/set-service`


------
https://chatgpt.com/codex/tasks/task_e_684aec125350832ebf4298fe5b559839