### PR TITLE
Improve search UX when no sets found

### DIFF
--- a/backend/data-service/db/db.go
+++ b/backend/data-service/db/db.go
@@ -2,9 +2,9 @@ package db
 
 import (
 	"data-service/models"
+	"fmt"
 	"log"
 	"os"
-	"fmt"
 
 	_ "github.com/lib/pq"
 	"gorm.io/driver/postgres"
@@ -15,16 +15,16 @@ var DB *gorm.DB
 
 func Init() error {
 	host := os.Getenv("DB_HOST")
-    port := os.Getenv("DB_PORT")
-    user := os.Getenv("DB_USER")
-    pass := os.Getenv("DB_PASSWORD")
+	port := os.Getenv("DB_PORT")
+	user := os.Getenv("DB_USER")
+	pass := os.Getenv("DB_PASSWORD")
 
-    dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s sslmode=disable",
-        host, port, user, pass,
-    )
-    var err error
-    DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
-    if err != nil {
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s sslmode=disable",
+		host, port, user, pass,
+	)
+	var err error
+	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
 		return err
 	}
 	log.Println("Database connection established")
@@ -33,6 +33,7 @@ func Init() error {
 	err = DB.AutoMigrate(
 		&models.Series{},
 		&models.Set{},
+		&models.Minifig{},
 		&models.User{},
 	)
 	if err != nil {

--- a/backend/data-service/handlers/minifigs.go
+++ b/backend/data-service/handlers/minifigs.go
@@ -22,19 +22,19 @@ import (
 // @Failure 500
 // @Router /api/lego/minifigs [post]
 func CreateMinifigsHandler(c *gin.Context) {
-	var series models.Series
-	if err := c.ShouldBindJSON(&series); err != nil {
+	var fig models.Minifig
+	if err := c.ShouldBindJSON(&fig); err != nil {
 		c.JSON(400, gin.H{"error": "Invalid request body"})
 		return
 	}
 
-	if err := db.DB.Create(&series).Error; err != nil {
-		log.Printf("Failed to save series: %v", err)
-		c.JSON(500, gin.H{"error": "Failed to save series"})
+	if err := db.DB.Create(&fig).Error; err != nil {
+		log.Printf("Failed to save minifig: %v", err)
+		c.JSON(500, gin.H{"error": "Failed to save minifig"})
 		return
 	}
 
-	c.JSON(201, series)
+	c.JSON(201, fig)
 }
 
 // GetAllMinifigsHandler godoc
@@ -43,9 +43,9 @@ func CreateMinifigsHandler(c *gin.Context) {
 // @Router       /api/lego/minifigs [get]
 // @Tags lego
 func GetAllMinifigsHandler(c *gin.Context) {
-	var products []models.Series
-	db.DB.Find(&products)
+	var figs []models.Minifig
+	db.DB.Find(&figs)
 	c.JSON(http.StatusOK, gin.H{
-		"data": products,
+		"data": figs,
 	})
 }

--- a/backend/data-service/main.go
+++ b/backend/data-service/main.go
@@ -43,6 +43,8 @@ func main() {
 		api.GET("/lego/series", handlers.GetAllSeriesHandler)
 		api.POST("/lego/sets", handlers.CreateSetHandler)
 		api.GET("/lego/sets", handlers.GetAllSetHandler)
+		api.POST("/lego/minifigs", handlers.CreateMinifigsHandler)
+		api.GET("/lego/minifigs", handlers.GetAllMinifigsHandler)
 		api.GET("/users", handlers.GetAllUsersHandler)
 		api.POST("/users", handlers.GetAllUsersHandler)
 	}

--- a/backend/data-service/models/minifig.go
+++ b/backend/data-service/models/minifig.go
@@ -1,0 +1,10 @@
+package models
+
+type Minifig struct {
+	SetNum         string `gorm:"primaryKey" json:"set_num"`
+	Name           string `gorm:"size:255;not null" json:"name"`
+	NumParts       int    `json:"num_parts"`
+	SetImgURL      string `json:"set_img_url"`
+	SetURL         string `json:"set_url"`
+	LastModifiedDT string `json:"last_modified_dt"`
+}

--- a/backend/set-service/handlers/minifigs.go
+++ b/backend/set-service/handlers/minifigs.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"os"
+	"set-service/services"
 
 	"github.com/gin-gonic/gin"
 )
@@ -23,13 +25,18 @@ func ImportMinifigsHandler(c *gin.Context) {
 		return
 	}
 
-	//Берем все минифигурки из Rebrickable
-	//series, err := services.FetchAllMinifigs(apiKey)
-	//if err != nil {
-	//	log.Printf("Failed to fetch series: %v", err) // <-- лог
-	//	c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get themes"})
-	//	return
-	//}
+	figs, err := services.FetchAllMinifigs(apiKey)
+	if err != nil {
+		log.Printf("Failed to fetch minifigs: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get minifigs"})
+		return
+	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "series imported successfully"})
+	for _, f := range figs {
+		if err := services.SendMinifigToDataService(f); err != nil {
+			log.Printf("Error sending minifig %s: %v", f.Name, err)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "minifigs imported successfully"})
 }

--- a/backend/set-service/main.go
+++ b/backend/set-service/main.go
@@ -47,6 +47,7 @@ func main() {
 		api.GET("/sets", setsHandler.GetSets)
 		api.POST("/import/series", handlers.ImportSeriesHandler)
 		api.POST("/import/sets", handlers.ImportSetsHandler)
+		api.POST("/import/minifigs", handlers.ImportMinifigsHandler)
 	}
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/backend/set-service/models/minifig.go
+++ b/backend/set-service/models/minifig.go
@@ -1,0 +1,17 @@
+package models
+
+type Minifig struct {
+	SetNum         string `json:"set_num"`
+	Name           string `json:"name"`
+	NumParts       int    `json:"num_parts"`
+	SetImgURL      string `json:"set_img_url"`
+	SetURL         string `json:"set_url"`
+	LastModifiedDT string `json:"last_modified_dt"`
+}
+
+type MinifigsResponse struct {
+	Count    int       `json:"count"`
+	Next     string    `json:"next"`
+	Previous string    `json:"previous"`
+	Results  []Minifig `json:"results"`
+}

--- a/backend/set-service/services/sendToDB.go
+++ b/backend/set-service/services/sendToDB.go
@@ -8,8 +8,8 @@ import (
 	"set-service/models"
 )
 
-func SendSeriesToDataService(theme models.Series) error {
-	jsonData, _ := json.Marshal(theme)
+func SendSeriesToDataService(series models.Series) error {
+	jsonData, _ := json.Marshal(series)
 	resp, err := http.Post("http://localhost:8081/api/lego/series", "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return err
@@ -22,9 +22,23 @@ func SendSeriesToDataService(theme models.Series) error {
 	return nil
 }
 
-func SendSetToDataService(theme models.Set) error {
-	jsonData, _ := json.Marshal(theme)
+func SendSetToDataService(set models.Set) error {
+	jsonData, _ := json.Marshal(set)
 	resp, err := http.Post("http://localhost:8081/api/lego/sets", "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("data-service returned status: %s", resp.Status)
+	}
+	return nil
+}
+
+func SendMinifigToDataService(fig models.Minifig) error {
+	jsonData, _ := json.Marshal(fig)
+	resp, err := http.Post("http://localhost:8081/api/lego/minifigs", "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return err
 	}

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -73,6 +73,7 @@ body {
 .search-results { max-height:150px; overflow-y:auto; margin-top:2px; background:#fff; border:1px solid #ccc; border-radius:8px; position:absolute; width:100%; z-index:1000; }
 .search-item { padding:4px 8px; cursor:pointer; }
 .search-item:hover { background:#eee; }
+.no-results { cursor:default; color:#888; }
 
 .nav-login {
   margin-left: 20px;

--- a/frontend/js/search.js
+++ b/frontend/js/search.js
@@ -28,13 +28,20 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await res.json();
       const results = data.data || [];
       container.innerHTML = '';
-      results.forEach(s => {
+      if (results.length === 0) {
         const div = document.createElement('div');
-        div.className = 'search-item';
-        div.textContent = `${s.set_num} - ${s.name}`;
+        div.className = 'search-item no-results';
+        div.textContent = 'Ничего не найдено';
         container.appendChild(div);
-      });
-      container.style.display = results.length ? 'block' : 'none';
+      } else {
+        results.forEach(s => {
+          const div = document.createElement('div');
+          div.className = 'search-item';
+          div.textContent = `${s.set_num} - ${s.name}`;
+          container.appendChild(div);
+        });
+      }
+      container.style.display = 'block';
     } catch (_) {
       container.style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- handle empty search results on the main page
- style the no-results message in the dropdown
- add minifig model and API routes
- implement minifig import logic from Rebrickable
- fix resource cleanup in the Rebrickable client

## Testing
- `go vet ./...` in data-service
- `go vet ./...` in set-service

------
https://chatgpt.com/codex/tasks/task_e_684af2b930f0832e818dc41fbc1e3b53