### PR TITLE
Search overlay for collection page

### DIFF
--- a/frontend/css/collection.css
+++ b/frontend/css/collection.css
@@ -28,10 +28,29 @@
 .form-buttons { display:flex; justify-content:space-between; margin-bottom:15px; }
 .btn-delete { background:#e57373; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
 .btn-save { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
-.search-add { display:flex; gap:10px; align-items:center; margin:10px 0; }
+.search-add {
+  display:flex;
+  gap:10px;
+  align-items:center;
+  margin:10px 0;
+  position:relative;
+}
 .search-input { flex:1; padding:8px; border:1px solid #ccc; border-radius:20px; font-size:14px; }
 .btn-add-set { background:#a4eb34; border:none; border-radius:20px; padding:6px 16px; font-size:14px; color:#fff; cursor:pointer; }
-.search-results { max-height:150px; overflow-y:auto; margin-bottom:10px; background:#fff; border:1px solid #ccc; border-radius:8px; }
+.search-results {
+  max-height:150px;
+  overflow-y:auto;
+  margin-top:2px;
+  background:#fff;
+  border:1px solid #ccc;
+  border-radius:8px;
+  position:absolute;
+  left:0;
+  right:0;
+  top:100%;
+  display:none;
+  z-index:1000;
+}
 .search-item { padding:4px 8px; cursor:pointer; }
 .search-item:hover { background:#eee; }
 .sets-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:20px; }

--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -104,6 +104,7 @@ async function fetchSearchResults() {
   const container = document.getElementById('search-results');
   if (!query) {
     container.innerHTML = '';
+    container.style.display = 'none';
     return;
   }
 
@@ -115,17 +116,26 @@ async function fetchSearchResults() {
   const data = await res.json();
   const results = data.data || [];
   container.innerHTML = '';
-  results.forEach(s => {
+  if (results.length === 0) {
     const div = document.createElement('div');
-    div.className = 'search-item';
-    div.textContent = `${s.set_num} - ${s.name}`;
-    div.addEventListener('click', () => {
-      addSetToCurrent(s);
-      container.innerHTML = '';
-      document.getElementById('search-input-set').value = '';
-    });
+    div.className = 'search-item no-results';
+    div.textContent = 'Ничего не найдено';
     container.appendChild(div);
-  });
+  } else {
+    results.forEach(s => {
+      const div = document.createElement('div');
+      div.className = 'search-item';
+      div.textContent = `${s.set_num} - ${s.name}`;
+      div.addEventListener('click', () => {
+        addSetToCurrent(s);
+        container.innerHTML = '';
+        document.getElementById('search-input-set').value = '';
+        container.style.display = 'none';
+      });
+      container.appendChild(div);
+    });
+  }
+  container.style.display = 'block';
 }
 
 function searchSets() {
@@ -171,6 +181,14 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('list-form').addEventListener('submit', saveCurrentList);
   document.getElementById('edit-btn').addEventListener('click', editList);
   document.getElementById('add-set-btn').addEventListener('click', fetchSearchResults);
-  document.getElementById('search-input-set').addEventListener('input', searchSets);
+  const searchInputSet = document.getElementById('search-input-set');
+  const resultsContainer = document.getElementById('search-results');
+  resultsContainer.style.display = 'none';
+  searchInputSet.addEventListener('input', searchSets);
+  document.addEventListener('click', (e) => {
+    if (!resultsContainer.contains(e.target) && e.target !== searchInputSet) {
+      resultsContainer.style.display = 'none';
+    }
+  });
   initHeader();
 });


### PR DESCRIPTION
## Summary
- show live search results when adding sets to a collection
- hide search results when query is cleared or clicking outside
- style search results overlay on the collection page

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684afa30ce04832e9df1fa2da6a719cf