### PR TITLE
Add live search previews for set lists

### DIFF
--- a/frontend/css/collection.css
+++ b/frontend/css/collection.css
@@ -51,8 +51,27 @@
   display:none;
   z-index:1000;
 }
-.search-item { padding:4px 8px; cursor:pointer; }
+.search-item {
+  padding:4px 8px;
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
 .search-item:hover { background:#eee; }
+.search-item img {
+  width:40px;
+  height:40px;
+  object-fit:cover;
+  border-radius:4px;
+}
+.search-item .set-num {
+  font-weight:bold;
+  margin-right:4px;
+}
+.search-item .set-name {
+  flex:1;
+}
 .sets-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:20px; }
 .set-card { background:#fff; border:1px solid #ddd; border-radius:8px; overflow:hidden; }
 .set-card img { width:100%; height:135px; object-fit:cover; }

--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -125,7 +125,11 @@ async function fetchSearchResults() {
     results.forEach(s => {
       const div = document.createElement('div');
       div.className = 'search-item';
-      div.textContent = `${s.set_num} - ${s.name}`;
+      div.innerHTML = `
+        <img src="${s.set_img_url || '../assets/sets.jpg'}" alt="${s.set_num}">
+        <span class="set-num">${s.set_num}</span>
+        <span class="set-name">${s.name}</span>
+      `;
       div.addEventListener('click', () => {
         addSetToCurrent(s);
         container.innerHTML = '';
@@ -185,6 +189,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsContainer = document.getElementById('search-results');
   resultsContainer.style.display = 'none';
   searchInputSet.addEventListener('input', searchSets);
+  searchInputSet.addEventListener('focus', () => {
+    if (searchInputSet.value.trim()) {
+      fetchSearchResults();
+    } else if (resultsContainer.innerHTML) {
+      resultsContainer.style.display = 'block';
+    }
+  });
   document.addEventListener('click', (e) => {
     if (!resultsContainer.contains(e.target) && e.target !== searchInputSet) {
       resultsContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- show preview image, set number and name when searching sets on collection page
- expand search results when the input is focused

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684afe5289a8832eb7361b09c9dcbfd6