### PR TITLE
Fix search results alignment

### DIFF
--- a/frontend/pages/collection.html
+++ b/frontend/pages/collection.html
@@ -59,8 +59,8 @@
         <div class="search-add">
           <input type="text" id="search-input-set" class="search-input" placeholder="Поиск по артикулу/названию">
           <button type="button" id="add-set-btn" class="btn-add-set">Добавить набор</button>
+          <div id="search-results" class="search-results"></div>
         </div>
-        <div id="search-results" class="search-results"></div>
         <div class="sets-grid"></div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- fix search results dropdown placement on the collection page

## Testing
- `go vet ./...` *(fails: Forbidden when fetching modules)*
- `go vet ./...` in `set-service`
- `go vet ./...` in `data-service`
- `go vet ./...` in `users-service`

------
https://chatgpt.com/codex/tasks/task_e_684aff695ed4832eb59e066b2759e1c5