### PR TITLE
Fix layout of new list button

### DIFF
--- a/frontend/js/collection.js
+++ b/frontend/js/collection.js
@@ -26,7 +26,12 @@ function renderLists() {
     listContainer.appendChild(li);
   });
   if (!panel.contains(listContainer)) {
-    panel.appendChild(listContainer);
+    const btn = panel.querySelector('.new-list-btn');
+    if (btn) {
+      panel.insertBefore(listContainer, btn);
+    } else {
+      panel.appendChild(listContainer);
+    }
   }
 }
 

--- a/frontend/pages/collection.html
+++ b/frontend/pages/collection.html
@@ -34,8 +34,8 @@
       <aside class="lists-panel">
         <h3>Списки:</h3>
         <!-- списки -->
+        <button class="btn-primary new-list-btn">Новый список наборов</button>
       </aside>
-      <button class="btn-primary new-list-btn">Новый список наборов</button>
       <section class="lists-overview" style="display:none"></section>
       <section class="empty-state">
         <p>Пока не создано ни одного списка.<br>Создайте новый список и добавьте первый набор в коллекцию</p>


### PR DESCRIPTION
## Summary
- move the "new list" button inside the list panel on the Collection page
- ensure the list container is inserted before the button in JS

## Testing
- `go vet ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b049a52a0832e871db9544febe0af